### PR TITLE
Fix joystick axis scan

### DIFF
--- a/Assets/InputManager/Source/Runtime/InputManager.cs
+++ b/Assets/InputManager/Source/Runtime/InputManager.cs
@@ -1072,7 +1072,7 @@ namespace TeamUtility.IO
 			_instance._scanJoystick = joystick;
 			_instance._scanUserData = userData;
 			_instance._scanHandler = (result) => {
-				return scanHandler(result.mouseAxis, (object[])result.userData);
+				return scanHandler(result.joystickAxis, (object[])result.userData);
 			};
 		}
 		


### PR DESCRIPTION
Handlers always get a -1 since the joystick axis scan reads the joystick input, but returns the mouse axis instead.