### PR TITLE
Input Manager creation to mark scene dirty

### DIFF
--- a/Assets/InputManager/Source/Editor/_Support/MenuCommands.cs
+++ b/Assets/InputManager/Source/Editor/_Support/MenuCommands.cs
@@ -33,7 +33,10 @@ namespace TeamUtilityEditor.IO.InputManager
 		{
 			GameObject gameObject = new GameObject("Input Manager");
 			gameObject.AddComponent<TeamUtility.IO.InputManager>();
-			
+
+			// Register Input Manager for undo, mark scene as dirty.
+			Undo.RegisterCreatedObjectUndo(gameObject, "Create Input Manager");
+
 			Selection.activeGameObject = gameObject;
 		}
 


### PR DESCRIPTION
Input Manager creation marks scene dirty and puts entry in UndoRedo
menu.